### PR TITLE
fix(core): Model version is now resolved correctly before a snapshot is created.

### DIFF
--- a/libs/core/src/lib/storage/abstract-event-store.spec.ts
+++ b/libs/core/src/lib/storage/abstract-event-store.spec.ts
@@ -250,6 +250,25 @@ describe("AbstractEventStore", () => {
             expect(snapshotStore.create).toHaveBeenCalledWith(entity);
         });
 
+        test("publisher resolves the aggregate version before creating the snapshot", async () => {
+            let versionWhenSnapshotIsCreated: number | undefined;
+            const snapshotStore = createMock<AbstractSnapshotStore>({
+                create: jest.fn().mockImplementation((aggregateRoot: AggregateRoot) => {
+                    versionWhenSnapshotIsCreated = aggregateRoot.version;
+                    return Promise.resolve({});
+                }),
+                shouldCreateSnapshot: jest.fn().mockReturnValue(true)
+            });
+
+            const store = new TestStore(eventEmitter, snapshotStore);
+            const entity = store.addPublisher(new TestEntity());
+            const toPublish = [{ aggregateRootId: "id", occurredAt: new Date(), payload: new TestEvent("test") }];
+            await entity.publish(toPublish);
+
+            expect(versionWhenSnapshotIsCreated).toBe(100);
+            expect(entity.version).toBe(100);
+        });
+
         test("publisher stop execution in case shouldCreateSnapshot throws", async () => {
             const createSnapshotError = new Error("createSnapshotError");
             const snapshotStore = createMock<AbstractSnapshotStore>({

--- a/libs/core/src/lib/storage/abstract-event-store.ts
+++ b/libs/core/src/lib/storage/abstract-event-store.ts
@@ -48,6 +48,9 @@ export abstract class AbstractEventStore implements EventStore {
             if (ids.length !== events.length || !hasAllValues(ids)) {
                 throw new IdGenerationException(ids.length, events.length);
             }
+            // This decision has to be made before the events are saved because strategies like
+            // ForCountSnapshotStrategy project the future version based on the current version and the
+            // uncommitted events. After saving, the resolved version would break that projection.
             const shouldCreateSnapshot = this._snapshotStore.shouldCreateSnapshot(aggregateRoot);
             const published: Array<PublishedDomainEvent<object>> = [];
             const storedEvents: Array<StoredEvent> = [];
@@ -73,6 +76,11 @@ export abstract class AbstractEventStore implements EventStore {
             const toStore = new StoredAggregateRoot(aggregateRoot.id, aggregateRoot.version);
             const saved = await this.save(storedEvents, toStore);
 
+            // The version has to be resolved before the snapshot is created. Otherwise, the snapshot metadata
+            // would point to the pre-save version while its payload already includes the new events, and those
+            // events would be replayed on top of the snapshot during reconstitution.
+            aggregateRoot.resolveVersion(saved);
+
             if (shouldCreateSnapshot) {
                 await this._snapshotStore.create(aggregateRoot);
             }
@@ -86,7 +94,6 @@ export abstract class AbstractEventStore implements EventStore {
                 publishedEvent.version = found.aggregateRootVersion;
             }
 
-            aggregateRoot.resolveVersion(saved);
             await this._eventEmitter.emitMultiple(published);
             return saved;
         };

--- a/libs/mongodb/src/lib/storage/mongo-event-store.spec.ts
+++ b/libs/mongodb/src/lib/storage/mongo-event-store.spec.ts
@@ -2,9 +2,11 @@ import {
     AggregateRoot,
     AggregateRootConfig,
     AggregateRootName,
+    ApplyEvent,
     DomainEvent,
     DomainEventEmitter,
     EventConcurrencyException,
+    ForCountSnapshotStrategy,
     getAggregateRootName,
     MissingAggregateRootNameException,
     NoOpSnapshotStore,
@@ -22,6 +24,37 @@ import { MongoSnapshotStore } from "./mongo-snapshot-store";
 
 interface TestSnapshot {
     someData: string;
+}
+
+@DomainEvent("counter-incremented-event")
+class CounterIncrementedEvent {}
+
+@AggregateRootConfig({ name: "counter-aggregate", snapshotRevision: 1 })
+class CounterSnapshotAggregateRoot extends AggregateRoot implements SnapshotAware<{ count: number }> {
+    count = 0;
+
+    constructor(id: string) {
+        super(id);
+    }
+
+    applySnapshot(snapshot: { count: number }): void {
+        this.count = snapshot.count;
+    }
+
+    increment() {
+        const event = new CounterIncrementedEvent();
+        this.applyCounterIncrementedEvent();
+        this.append(event);
+    }
+
+    toSnapshot(): { count: number } {
+        return { count: this.count };
+    }
+
+    @ApplyEvent(CounterIncrementedEvent)
+    private applyCounterIncrementedEvent() {
+        this.count += 1;
+    }
 }
 
 @AggregateRootName("test-aggregate")
@@ -946,6 +979,73 @@ describe("MongoEventStore", () => {
             expect(result.events.length).toBe(2);
             expect(result.events[0].aggregateRootVersion).toBe(5);
             expect(result.events[1].aggregateRootVersion).toBe(10);
+        });
+    });
+
+    describe("publisher round trip with snapshots", () => {
+        let realSnapshotStore: MongoSnapshotStore;
+        let storeWithSnapshots: MongoEventStore;
+
+        beforeEach(async () => {
+            const snapshotsCollection = mongoClient.db().collection("snapshots");
+            await snapshotsCollection.deleteMany({});
+            realSnapshotStore = new MongoSnapshotStore(
+                new ForCountSnapshotStrategy({ count: 2 }),
+                mongoClient,
+                "snapshots"
+            );
+            storeWithSnapshots = new MongoEventStore(
+                createMock<DomainEventEmitter>(),
+                realSnapshotStore,
+                mongoClient,
+                "aggregates",
+                "events"
+            );
+        });
+
+        test("creates the snapshot with the committed version so that snapshotted events are not replayed", async () => {
+            const aggregateRootId = new ObjectId().toHexString();
+            const aggregate = storeWithSnapshots.addPublisher(new CounterSnapshotAggregateRoot(aggregateRootId));
+            aggregate.increment();
+            aggregate.increment();
+            await aggregate.commit();
+
+            expect(aggregate.version).toBe(2);
+
+            const storedSnapshot = await realSnapshotStore.findLatestSnapshotByAggregateId(aggregateRootId);
+            expect(storedSnapshot?.aggregateRootVersion).toBe(2);
+            expect(storedSnapshot?.payload).toEqual({ count: 2 });
+
+            const found = await storeWithSnapshots.findWithSnapshot(CounterSnapshotAggregateRoot, aggregateRootId);
+            expect(found.events.length).toBe(0);
+            expect(found.aggregateRootVersion).toBe(2);
+            expect(found.snapshot).toEqual({ count: 2 });
+
+            const reloaded = new CounterSnapshotAggregateRoot(aggregateRootId);
+            reloaded.reconstitute(found.events, found.snapshot, found.aggregateRootVersion);
+            expect(reloaded.count).toBe(2);
+            expect(reloaded.version).toBe(2);
+        });
+
+        test("replays only the events that were committed after the snapshot", async () => {
+            const aggregateRootId = new ObjectId().toHexString();
+            const aggregate = storeWithSnapshots.addPublisher(new CounterSnapshotAggregateRoot(aggregateRootId));
+            aggregate.increment();
+            aggregate.increment();
+            await aggregate.commit();
+
+            aggregate.increment();
+            await aggregate.commit();
+
+            const found = await storeWithSnapshots.findWithSnapshot(CounterSnapshotAggregateRoot, aggregateRootId);
+            expect(found.events.length).toBe(1);
+            expect(found.events[0].aggregateRootVersion).toBe(3);
+            expect(found.aggregateRootVersion).toBe(3);
+
+            const reloaded = new CounterSnapshotAggregateRoot(aggregateRootId);
+            reloaded.reconstitute(found.events, found.snapshot, found.aggregateRootVersion);
+            expect(reloaded.count).toBe(3);
+            expect(reloaded.version).toBe(3);
         });
     });
 });


### PR DESCRIPTION
## Summary by Sourcery

Ensure snapshots are created with the correct, resolved aggregate root version so snapshotted events are not replayed during reconstitution.

Bug Fixes:
- Fix snapshot creation to use the committed aggregate root version instead of the pre-save version, preventing replay of snapshotted events.

Enhancements:
- Add a counter-based aggregate root and end-to-end MongoDB event store tests to verify snapshot behavior and event replay semantics.
- Extend abstract event store tests to validate that publisher resolves the aggregate version before snapshot creation.