### PR TITLE
fix(core): Asynchronous snapshot strategies are now awaited before deciding to create a snapshot

### DIFF
--- a/libs/core/src/lib/snapshot-strategy/all-of-snapshot-strategy.spec.ts
+++ b/libs/core/src/lib/snapshot-strategy/all-of-snapshot-strategy.spec.ts
@@ -21,6 +21,18 @@ class AlwaysTrueStrategy extends SnapshotStrategy {
     }
 }
 
+class AsyncFalseStrategy extends SnapshotStrategy {
+    shouldCreateSnapshot(): Promise<boolean> {
+        return Promise.resolve(false);
+    }
+}
+
+class AsyncTrueStrategy extends SnapshotStrategy {
+    shouldCreateSnapshot(): Promise<boolean> {
+        return Promise.resolve(true);
+    }
+}
+
 @AggregateRootName("TestAggregateRoot")
 class TestAggregateRoot extends AggregateRoot {
     constructor(id: string) {
@@ -50,14 +62,14 @@ describe("AllOfSnapshotStrategy", () => {
 
     describe("shouldCreateSnapshot", () => {
         describe("when it returns true", () => {
-            test("returns true when single strategy returns true", () => {
+            test("returns true when single strategy returns true", async () => {
                 const aggregateRoot = new TestAggregateRoot("test-id");
                 const strategy = new AllOfSnapshotStrategy([new AlwaysTrueStrategy()]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when multiple strategies return true", () => {
+            test("returns true when multiple strategies return true", async () => {
                 const aggregateRoot = new TestAggregateRoot("test-id");
                 const strategy = new AllOfSnapshotStrategy([
                     new AlwaysTrueStrategy(),
@@ -65,10 +77,17 @@ describe("AllOfSnapshotStrategy", () => {
                     new AlwaysTrueStrategy()
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when all real strategies match", () => {
+            test("returns true when synchronous and asynchronous strategies all match", async () => {
+                const aggregateRoot = new TestAggregateRoot("test-id");
+                const strategy = new AllOfSnapshotStrategy([new AlwaysTrueStrategy(), new AsyncTrueStrategy()]);
+
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
+            });
+
+            test("returns true when all real strategies match", async () => {
                 const aggregateRoot = createMock<AggregateRoot>({
                     uncommittedEvents: [
                         {
@@ -83,10 +102,10 @@ describe("AllOfSnapshotStrategy", () => {
                     new ForEventsSnapshotStrategy({ eventClasses: [TestEvent1] })
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when multiple count and event strategies all match", () => {
+            test("returns true when multiple count and event strategies all match", async () => {
                 const aggregateRoot = createMock<AggregateRoot>({
                     uncommittedEvents: [
                         {
@@ -102,20 +121,20 @@ describe("AllOfSnapshotStrategy", () => {
                     new AlwaysTrueStrategy()
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
         });
     });
 
     describe("when it returns false", () => {
-        test("returns false when single strategy returns false", () => {
+        test("returns false when single strategy returns false", async () => {
             const aggregateRoot = new TestAggregateRoot("test-id");
             const strategy = new AllOfSnapshotStrategy([new AlwaysFalseStrategy()]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when at least one strategy returns false", () => {
+        test("returns false when at least one strategy returns false", async () => {
             const aggregateRoot = new TestAggregateRoot("test-id");
             const strategy = new AllOfSnapshotStrategy([
                 new AlwaysTrueStrategy(),
@@ -123,10 +142,17 @@ describe("AllOfSnapshotStrategy", () => {
                 new AlwaysTrueStrategy()
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when count strategy does not match", () => {
+        test("returns false when an asynchronous strategy resolves to false", async () => {
+            const aggregateRoot = new TestAggregateRoot("test-id");
+            const strategy = new AllOfSnapshotStrategy([new AlwaysTrueStrategy(), new AsyncFalseStrategy()]);
+
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
+        });
+
+        test("returns false when count strategy does not match", async () => {
             const aggregateRoot = new TestAggregateRoot("test-id");
             const event1 = new TestEvent1();
             aggregateRoot.append(event1);
@@ -136,10 +162,10 @@ describe("AllOfSnapshotStrategy", () => {
                 new ForEventsSnapshotStrategy({ eventClasses: [TestEvent1] })
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when event strategy does not match", () => {
+        test("returns false when event strategy does not match", async () => {
             const aggregateRoot = createMock<AggregateRoot>({
                 uncommittedEvents: [
                     {
@@ -154,10 +180,10 @@ describe("AllOfSnapshotStrategy", () => {
                 new ForEventsSnapshotStrategy({ eventClasses: [TestEvent2] })
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when only some strategies match", () => {
+        test("returns false when only some strategies match", async () => {
             const aggregateRoot = createMock<AggregateRoot>({
                 uncommittedEvents: [
                     {
@@ -173,10 +199,10 @@ describe("AllOfSnapshotStrategy", () => {
                 new AlwaysFalseStrategy()
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when aggregate strategy does not match", () => {
+        test("returns false when aggregate strategy does not match", async () => {
             const aggregateRoot = createMock<AggregateRoot>({
                 uncommittedEvents: [
                     {
@@ -192,7 +218,7 @@ describe("AllOfSnapshotStrategy", () => {
                 new ForAggregateRootsStrategy({ aggregates: [TestAggregateRoot2] })
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
     });
 });

--- a/libs/core/src/lib/snapshot-strategy/all-of-snapshot-strategy.ts
+++ b/libs/core/src/lib/snapshot-strategy/all-of-snapshot-strategy.ts
@@ -31,7 +31,10 @@ export class AllOfSnapshotStrategy extends SnapshotStrategy {
         }
     }
 
-    shouldCreateSnapshot(aggregateRoot: AggregateRoot): boolean {
-        return this.strategies.every((strategy) => strategy.shouldCreateSnapshot(aggregateRoot));
+    async shouldCreateSnapshot(aggregateRoot: AggregateRoot): Promise<boolean> {
+        const results = await Promise.all(
+            this.strategies.map((strategy) => strategy.shouldCreateSnapshot(aggregateRoot))
+        );
+        return results.every(Boolean);
     }
 }

--- a/libs/core/src/lib/snapshot-strategy/any-of-snapshot-strategy.spec.ts
+++ b/libs/core/src/lib/snapshot-strategy/any-of-snapshot-strategy.spec.ts
@@ -20,6 +20,18 @@ class AlwaysTrueStrategy extends SnapshotStrategy {
     }
 }
 
+class AsyncFalseStrategy extends SnapshotStrategy {
+    shouldCreateSnapshot(): Promise<boolean> {
+        return Promise.resolve(false);
+    }
+}
+
+class AsyncTrueStrategy extends SnapshotStrategy {
+    shouldCreateSnapshot(): Promise<boolean> {
+        return Promise.resolve(true);
+    }
+}
+
 @AggregateRootConfig({ name: "TestAggregateRoot" })
 class TestAggregateRoot extends AggregateRoot {
     constructor(id: string) {
@@ -46,14 +58,14 @@ describe("AnyOfSnapshotStrategy", () => {
 
     describe("shouldCreateSnapshot", () => {
         describe("when it returns true", () => {
-            test("returns true when single strategy match", () => {
+            test("returns true when single strategy match", async () => {
                 const aggregateRoot = new TestAggregateRoot("test-id");
                 const strategy = new AnyOfSnapshotStrategy([new AlwaysTrueStrategy()]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when all strategies match", () => {
+            test("returns true when all strategies match", async () => {
                 const aggregateRoot = new TestAggregateRoot("test-id");
                 const strategy = new AnyOfSnapshotStrategy([
                     new AlwaysTrueStrategy(),
@@ -61,10 +73,10 @@ describe("AnyOfSnapshotStrategy", () => {
                     new AlwaysTrueStrategy()
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when at least one strategy matches", () => {
+            test("returns true when at least one strategy matches", async () => {
                 const aggregateRoot = new TestAggregateRoot("test-id");
                 const strategy = new AnyOfSnapshotStrategy([
                     new AlwaysFalseStrategy(),
@@ -72,10 +84,17 @@ describe("AnyOfSnapshotStrategy", () => {
                     new AlwaysFalseStrategy()
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when count strategy matches", () => {
+            test("returns true when only an asynchronous strategy matches", async () => {
+                const aggregateRoot = new TestAggregateRoot("test-id");
+                const strategy = new AnyOfSnapshotStrategy([new AlwaysFalseStrategy(), new AsyncTrueStrategy()]);
+
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
+            });
+
+            test("returns true when count strategy matches", async () => {
                 const aggregateRoot = createMock<AggregateRoot>({
                     uncommittedEvents: [
                         {
@@ -90,10 +109,10 @@ describe("AnyOfSnapshotStrategy", () => {
                     new ForEventsSnapshotStrategy({ eventClasses: [TestEvent2] })
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
 
-            test("returns true when event strategy matches", () => {
+            test("returns true when event strategy matches", async () => {
                 const aggregateRoot = new TestAggregateRoot("test-id");
                 const event1 = new TestEvent1();
                 aggregateRoot.append(event1);
@@ -103,20 +122,20 @@ describe("AnyOfSnapshotStrategy", () => {
                     new ForEventsSnapshotStrategy({ eventClasses: [TestEvent1] })
                 ]);
 
-                expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(true);
+                await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(true);
             });
         });
     });
 
     describe("when it returns false", () => {
-        test("returns false when single strategy returns false", () => {
+        test("returns false when single strategy returns false", async () => {
             const aggregateRoot = new TestAggregateRoot("test-id");
             const strategy = new AnyOfSnapshotStrategy([new AlwaysFalseStrategy()]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when all strategies return false", () => {
+        test("returns false when all strategies return false", async () => {
             const aggregateRoot = new TestAggregateRoot("test-id");
             const strategy = new AnyOfSnapshotStrategy([
                 new AlwaysFalseStrategy(),
@@ -124,10 +143,17 @@ describe("AnyOfSnapshotStrategy", () => {
                 new AlwaysFalseStrategy()
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
 
-        test("returns false when no strategies match", () => {
+        test("returns false when all strategies are asynchronous and resolve to false", async () => {
+            const aggregateRoot = new TestAggregateRoot("test-id");
+            const strategy = new AnyOfSnapshotStrategy([new AsyncFalseStrategy(), new AsyncFalseStrategy()]);
+
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
+        });
+
+        test("returns false when no strategies match", async () => {
             const aggregateRoot = new TestAggregateRoot("test-id");
             const event1 = new TestEvent1();
             aggregateRoot.append(event1);
@@ -137,7 +163,7 @@ describe("AnyOfSnapshotStrategy", () => {
                 new ForEventsSnapshotStrategy({ eventClasses: [TestEvent2] })
             ]);
 
-            expect(strategy.shouldCreateSnapshot(aggregateRoot)).toBe(false);
+            await expect(strategy.shouldCreateSnapshot(aggregateRoot)).resolves.toBe(false);
         });
     });
 });

--- a/libs/core/src/lib/snapshot-strategy/any-of-snapshot-strategy.ts
+++ b/libs/core/src/lib/snapshot-strategy/any-of-snapshot-strategy.ts
@@ -32,7 +32,10 @@ export class AnyOfSnapshotStrategy extends SnapshotStrategy {
         }
     }
 
-    shouldCreateSnapshot(aggregateRoot: AggregateRoot): boolean {
-        return this.strategies.some((strategy) => strategy.shouldCreateSnapshot(aggregateRoot));
+    async shouldCreateSnapshot(aggregateRoot: AggregateRoot): Promise<boolean> {
+        const results = await Promise.all(
+            this.strategies.map((strategy) => strategy.shouldCreateSnapshot(aggregateRoot))
+        );
+        return results.some(Boolean);
     }
 }

--- a/libs/core/src/lib/storage/abstract-event-store.spec.ts
+++ b/libs/core/src/lib/storage/abstract-event-store.spec.ts
@@ -240,7 +240,7 @@ describe("AbstractEventStore", () => {
 
             const creationDate = new Date();
             const store = new TestStore(eventEmitter, snapshotStore);
-            const entity = store.addPublisher(new TestEntity());
+            const entity = store.addPublisher(new SnapshotEntity());
             const toPublish = [{ aggregateRootId: "id", occurredAt: creationDate, payload: new TestEvent("test") }];
             await entity.publish(toPublish);
 
@@ -248,6 +248,55 @@ describe("AbstractEventStore", () => {
             expect(snapshotStore.shouldCreateSnapshot).toHaveBeenCalledWith(entity);
             expect(snapshotStore.create).toHaveBeenCalledTimes(1);
             expect(snapshotStore.create).toHaveBeenCalledWith(entity);
+        });
+
+        test("publisher calls snapshotStore.create if an asynchronous strategy resolves to true", async () => {
+            const snapshotStore = createMock<AbstractSnapshotStore>({
+                create: jest.fn().mockResolvedValue({}),
+                shouldCreateSnapshot: jest.fn().mockResolvedValue(true)
+            });
+
+            const store = new TestStore(eventEmitter, snapshotStore);
+            const entity = store.addPublisher(new SnapshotEntity());
+            const toPublish = [{ aggregateRootId: "id", occurredAt: new Date(), payload: new TestEvent("test") }];
+            await entity.publish(toPublish);
+
+            expect(snapshotStore.create).toHaveBeenCalledTimes(1);
+            expect(snapshotStore.create).toHaveBeenCalledWith(entity);
+        });
+
+        test("publisher skips snapshot creation if an asynchronous strategy resolves to false", async () => {
+            const snapshotStore = createMock<AbstractSnapshotStore>({
+                create: jest.fn().mockResolvedValue({}),
+                shouldCreateSnapshot: jest.fn().mockResolvedValue(false)
+            });
+
+            const store = new TestStore(eventEmitter, snapshotStore);
+            const saveSpy = jest.spyOn(store, "save");
+            const entity = store.addPublisher(new SnapshotEntity());
+            const toPublish = [{ aggregateRootId: "id", occurredAt: new Date(), payload: new TestEvent("test") }];
+            await entity.publish(toPublish);
+
+            expect(snapshotStore.create).not.toHaveBeenCalled();
+            expect(saveSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test("publisher stop execution in case shouldCreateSnapshot rejects", async () => {
+            const strategyError = new Error("async strategy failed");
+            const snapshotStore = createMock<AbstractSnapshotStore>({
+                create: jest.fn().mockResolvedValue({}),
+                shouldCreateSnapshot: jest.fn().mockRejectedValue(strategyError)
+            });
+
+            const store = new TestStore(eventEmitter, snapshotStore);
+            const saveSpy = jest.spyOn(store, "save");
+            const entity = store.addPublisher(new SnapshotEntity());
+            const toPublish = [{ aggregateRootId: "id", occurredAt: new Date(), payload: new TestEvent("test") }];
+
+            await expect(entity.publish(toPublish)).rejects.toThrow(strategyError);
+            expect(saveSpy).not.toHaveBeenCalled();
+            expect(snapshotStore.create).not.toHaveBeenCalled();
+            expect(eventEmitter.emitMultiple).not.toHaveBeenCalled();
         });
 
         test("publisher resolves the aggregate version before creating the snapshot", async () => {
@@ -261,7 +310,7 @@ describe("AbstractEventStore", () => {
             });
 
             const store = new TestStore(eventEmitter, snapshotStore);
-            const entity = store.addPublisher(new TestEntity());
+            const entity = store.addPublisher(new SnapshotEntity());
             const toPublish = [{ aggregateRootId: "id", occurredAt: new Date(), payload: new TestEvent("test") }];
             await entity.publish(toPublish);
 

--- a/libs/core/src/lib/storage/abstract-event-store.ts
+++ b/libs/core/src/lib/storage/abstract-event-store.ts
@@ -4,6 +4,7 @@ import { isNil } from "es-toolkit";
 import { AggregateRoot } from "../aggregate-root/aggregate-root";
 import { getAggregateRootName, getAggregateRootSnapshotRevision } from "../aggregate-root/aggregate-root-config";
 import { AggregateRootEvent } from "../aggregate-root/aggregate-root-event";
+import { assertIsSnapshotAwareAggregateRoot } from "../aggregate-root/snapshot-aware";
 import { DomainEventEmitter } from "../domain-event-emitter";
 import { AggregateClassNotSnapshotAwareException } from "../exceptions/aggregate-class-not-snapshot-aware-exception";
 import { IdGenerationException } from "../exceptions/id-generation-exception";
@@ -51,7 +52,7 @@ export abstract class AbstractEventStore implements EventStore {
             // This decision has to be made before the events are saved because strategies like
             // ForCountSnapshotStrategy project the future version based on the current version and the
             // uncommitted events. After saving, the resolved version would break that projection.
-            const shouldCreateSnapshot = this._snapshotStore.shouldCreateSnapshot(aggregateRoot);
+            const shouldCreateSnapshot = await this._snapshotStore.shouldCreateSnapshot(aggregateRoot);
             const published: Array<PublishedDomainEvent<object>> = [];
             const storedEvents: Array<StoredEvent> = [];
 
@@ -82,6 +83,7 @@ export abstract class AbstractEventStore implements EventStore {
             aggregateRoot.resolveVersion(saved);
 
             if (shouldCreateSnapshot) {
+                assertIsSnapshotAwareAggregateRoot(aggregateRoot);
                 await this._snapshotStore.create(aggregateRoot);
             }
 

--- a/libs/core/src/lib/storage/snapshot/abstract-snapshot-store.spec.ts
+++ b/libs/core/src/lib/storage/snapshot/abstract-snapshot-store.spec.ts
@@ -207,45 +207,84 @@ describe("AbstractSnapshotStore", () => {
     });
 
     describe("shouldCreateSnapshot", () => {
-        test("returns false when strategy returns false", () => {
+        test("returns false when strategy returns false", async () => {
             mockStrategy.shouldCreateSnapshot.mockReturnValue(false);
             const aggregate = new NoNameAggregate("test-id");
 
-            const result = store.shouldCreateSnapshot(aggregate);
+            const result = await store.shouldCreateSnapshot(aggregate);
 
             expect(mockStrategy.shouldCreateSnapshot).toHaveBeenCalledTimes(1);
             expect(mockStrategy.shouldCreateSnapshot).toHaveBeenCalledWith(aggregate);
             expect(result).toBe(false);
         });
 
-        test("throws when aggregate root name is missing", () => {
+        test("throws when aggregate root name is missing", async () => {
             mockStrategy.shouldCreateSnapshot.mockReturnValue(true);
             const aggregate = new NoNameAggregate("test-id");
 
-            expect(() => store.shouldCreateSnapshot(aggregate)).toThrow(MissingAggregateRootNameException);
+            await expect(store.shouldCreateSnapshot(aggregate)).rejects.toThrow(MissingAggregateRootNameException);
         });
 
-        test("throws when aggregate instance is not snapshot aware", () => {
+        test("throws when aggregate instance is not snapshot aware", async () => {
             mockStrategy.shouldCreateSnapshot.mockReturnValue(true);
             const aggregate = new NoSnapshotMethodsAggregate("test-id");
 
-            expect(() => store.shouldCreateSnapshot(aggregate)).toThrow(AggregateInstanceNotSnapshotAwareException);
+            await expect(store.shouldCreateSnapshot(aggregate)).rejects.toThrow(
+                AggregateInstanceNotSnapshotAwareException
+            );
         });
 
-        test("throws when aggregate class is not snapshot aware", () => {
+        test("throws when aggregate class is not snapshot aware", async () => {
             mockStrategy.shouldCreateSnapshot.mockReturnValue(true);
             const aggregate = new NoSnapshotRevisionAggregate("test-id");
 
-            expect(() => store.shouldCreateSnapshot(aggregate)).toThrow(AggregateClassNotSnapshotAwareException);
+            await expect(store.shouldCreateSnapshot(aggregate)).rejects.toThrow(
+                AggregateClassNotSnapshotAwareException
+            );
         });
 
-        test("returns true for snapshot-aware aggregate with snapshotRevision", () => {
+        test("returns true for snapshot-aware aggregate with snapshotRevision", async () => {
             mockStrategy.shouldCreateSnapshot.mockReturnValue(true);
             const aggregate = new SnapshotAwareAggregate("test-id");
 
-            const result = store.shouldCreateSnapshot(aggregate);
+            const result = await store.shouldCreateSnapshot(aggregate);
 
             expect(result).toBe(true);
+        });
+
+        test("returns true when an asynchronous strategy resolves to true", async () => {
+            mockStrategy.shouldCreateSnapshot.mockResolvedValue(true);
+            const aggregate = new SnapshotAwareAggregate("test-id");
+
+            const result = await store.shouldCreateSnapshot(aggregate);
+
+            expect(result).toBe(true);
+        });
+
+        test("returns false when an asynchronous strategy resolves to false", async () => {
+            mockStrategy.shouldCreateSnapshot.mockResolvedValue(false);
+            const aggregate = new SnapshotAwareAggregate("test-id");
+
+            const result = await store.shouldCreateSnapshot(aggregate);
+
+            expect(result).toBe(false);
+        });
+
+        test("does not run snapshot-awareness checks when an asynchronous strategy resolves to false", async () => {
+            mockStrategy.shouldCreateSnapshot.mockResolvedValue(false);
+            const aggregate = new NoNameAggregate("test-id");
+
+            const result = await store.shouldCreateSnapshot(aggregate);
+
+            expect(result).toBe(false);
+        });
+
+        test("throws when an asynchronous strategy rejects", async () => {
+            const strategyError = new Error("strategy failed");
+            mockStrategy.shouldCreateSnapshot.mockRejectedValue(strategyError);
+            const aggregate = new SnapshotAwareAggregate("test-id");
+
+            await expect(store.shouldCreateSnapshot(aggregate)).rejects.toThrow(strategyError);
         });
     });
 });

--- a/libs/core/src/lib/storage/snapshot/abstract-snapshot-store.ts
+++ b/libs/core/src/lib/storage/snapshot/abstract-snapshot-store.ts
@@ -32,8 +32,8 @@ export abstract class AbstractSnapshotStore implements SnapshotStore {
     abstract generateEntityId(): Promise<string>;
     abstract save(snapshot: StoredSnapshot): Promise<StoredSnapshot | undefined>;
 
-    shouldCreateSnapshot(aggregateRoot: AggregateRoot): aggregateRoot is SnapshotAwareAggregateRoot {
-        if (!this.snapshotStrategy.shouldCreateSnapshot(aggregateRoot)) {
+    async shouldCreateSnapshot(aggregateRoot: AggregateRoot): Promise<boolean> {
+        if (!(await this.snapshotStrategy.shouldCreateSnapshot(aggregateRoot))) {
             return false;
         }
 

--- a/libs/core/src/lib/storage/snapshot/snapshot-store.ts
+++ b/libs/core/src/lib/storage/snapshot/snapshot-store.ts
@@ -45,10 +45,12 @@ export interface SnapshotStore {
     save(snapshot: StoredSnapshot): Promise<StoredSnapshot | undefined>;
 
     /**
-     * Asserts the snapshot should be created for an aggregate.
-     * The result assersion is used for .create() method of SnapshotStore
+     * Decides whether a snapshot should be created for an aggregate by evaluating the configured
+     * {@link SnapshotStrategy}. The strategy result is awaited, so both synchronous and asynchronous
+     * strategies are supported. When the result is true, the aggregate is guaranteed to be snapshot
+     * aware and can be safely passed to {@link SnapshotStore.create}.
      * @throws If the strategy matches, but the aggregate is not snapshot aware, an error will be thrown.
      * @param aggregate The aggregate root instance to potentially create a snapshot for
      */
-    shouldCreateSnapshot(aggregate: AggregateRoot): aggregate is SnapshotAwareAggregateRoot;
+    shouldCreateSnapshot(aggregate: AggregateRoot): Promise<boolean>;
 }

--- a/libs/mongodb/src/lib/storage/mongo-event-store.spec.ts
+++ b/libs/mongodb/src/lib/storage/mongo-event-store.spec.ts
@@ -12,6 +12,7 @@ import {
     NoOpSnapshotStore,
     SnapshotAware,
     SnapshotRevisionMismatchException,
+    SnapshotStrategy,
     StoredAggregateRoot,
     StoredEvent,
     StoredSnapshot
@@ -24,6 +25,16 @@ import { MongoSnapshotStore } from "./mongo-snapshot-store";
 
 interface TestSnapshot {
     someData: string;
+}
+
+class AsyncSnapshotStrategy extends SnapshotStrategy {
+    constructor(private readonly shouldCreate: boolean) {
+        super();
+    }
+
+    shouldCreateSnapshot(): Promise<boolean> {
+        return Promise.resolve(this.shouldCreate);
+    }
 }
 
 @DomainEvent("counter-incremented-event")
@@ -1046,6 +1057,57 @@ describe("MongoEventStore", () => {
             reloaded.reconstitute(found.events, found.snapshot, found.aggregateRootVersion);
             expect(reloaded.count).toBe(3);
             expect(reloaded.version).toBe(3);
+        });
+
+        test("creates a snapshot when an asynchronous strategy resolves to true", async () => {
+            const asyncSnapshotStore = new MongoSnapshotStore(
+                new AsyncSnapshotStrategy(true),
+                mongoClient,
+                "snapshots"
+            );
+            const asyncStore = new MongoEventStore(
+                createMock<DomainEventEmitter>(),
+                asyncSnapshotStore,
+                mongoClient,
+                "aggregates",
+                "events"
+            );
+
+            const aggregateRootId = new ObjectId().toHexString();
+            const aggregate = asyncStore.addPublisher(new CounterSnapshotAggregateRoot(aggregateRootId));
+            aggregate.increment();
+            await aggregate.commit();
+
+            const storedSnapshot = await asyncSnapshotStore.findLatestSnapshotByAggregateId(aggregateRootId);
+            expect(storedSnapshot?.aggregateRootVersion).toBe(1);
+            expect(storedSnapshot?.payload).toEqual({ count: 1 });
+        });
+
+        test("does not create a snapshot when an asynchronous strategy resolves to false", async () => {
+            const asyncSnapshotStore = new MongoSnapshotStore(
+                new AsyncSnapshotStrategy(false),
+                mongoClient,
+                "snapshots"
+            );
+            const asyncStore = new MongoEventStore(
+                createMock<DomainEventEmitter>(),
+                asyncSnapshotStore,
+                mongoClient,
+                "aggregates",
+                "events"
+            );
+
+            const aggregateRootId = new ObjectId().toHexString();
+            const aggregate = asyncStore.addPublisher(new CounterSnapshotAggregateRoot(aggregateRootId));
+            aggregate.increment();
+            await aggregate.commit();
+
+            const storedSnapshot = await asyncSnapshotStore.findLatestSnapshotByAggregateId(aggregateRootId);
+            expect(storedSnapshot).toBeUndefined();
+
+            const found = await asyncStore.findWithSnapshot(CounterSnapshotAggregateRoot, aggregateRootId);
+            expect(found.events.length).toBe(1);
+            expect(found.snapshot).toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
…ciding to create a snapshot.

## Summary by Sourcery

Await snapshot strategies before deciding snapshot creation and support asynchronous strategies across snapshot store and event store.

Bug Fixes:
- Ensure snapshot creation decision in AbstractEventStore waits for asynchronous snapshot strategies before saving events.
- Avoid running snapshot-awareness checks when snapshot strategies resolve to false, including for asynchronous strategies.
- Prevent snapshot creation and event emission when an asynchronous snapshot strategy rejects.

Enhancements:
- Update AllOfSnapshotStrategy and AnyOfSnapshotStrategy to support asynchronous snapshot strategies via Promise-based evaluation.
- Simplify snapshot awareness enforcement by moving aggregate snapshot-awareness assertion to AbstractEventStore before snapshot creation.
- Refine SnapshotStore.shouldCreateSnapshot API to return a Promise<boolean> instead of a type guard for broader strategy support.

Tests:
- Add coverage for AllOfSnapshotStrategy and AnyOfSnapshotStrategy behavior with mixed synchronous and asynchronous strategies.
- Extend AbstractSnapshotStore tests to cover asynchronous strategy results and error handling.
- Extend AbstractEventStore tests to validate snapshot creation behavior with asynchronous strategies and rejection handling.
- Add MongoEventStore tests to verify snapshot creation and omission when using asynchronous snapshot strategies.